### PR TITLE
Add pass_filenames: false to examples

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,6 +3,7 @@
   description: Runs OPA unit tests on rego source files
   entry: opa test
   args: ['.']
+  pass_filenames: false
   language: system
   files: (\.rego)$
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ Since it doesn't make sense to only provide `opa test` with the files changed (a
 ```yaml
 - id: opa-test
   args: ['my/policies', 'my/other/policies/']
-  pass_filenames: false
 ```
 
 #### `conftest-test`
@@ -54,7 +53,6 @@ Just like with `opa-test` you'll likely want to specify the location of your con
 - id: conftest-test
   args: ['--policy', 'conftest/policy']
   files: conftest/.*\.yaml$
-  pass_filenames: false
 ```
 
 #### `conftest-verify`

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Since it doesn't make sense to only provide `opa test` with the files changed (a
 ```yaml
 - id: opa-test
   args: ['my/policies', 'my/other/policies/']
+  pass_filenames: false
 ```
 
 #### `conftest-test`
@@ -53,6 +54,7 @@ Just like with `opa-test` you'll likely want to specify the location of your con
 - id: conftest-test
   args: ['--policy', 'conftest/policy']
   files: conftest/.*\.yaml$
+  pass_filenames: false
 ```
 
 #### `conftest-verify`


### PR DESCRIPTION
When specifying the paths to run for `opa-test`, it isn't sufficient to just add them to `args` since pre-commit will append the changed files to the command line, you also need to add `pass_filenames: false`

I'm just guessing that conftest has the same issue, but i have not tested it