### PR TITLE
Fix: conftest fmts all files

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -36,14 +36,12 @@
   description: Run `conftest fmt` on staged Rego files
   entry: conftest fmt
   language: system
-  args: ['.']
   files: (\.rego)$
 
 - id: conftest-verify
   name: Conftest verify
   description: Run `conftest verify` on rego files
   entry: conftest verify
-  args: ['.']
   pass_filenames: false
   language: system
   files: (\.rego)$


### PR DESCRIPTION
This PR fixes an issue with conftest-fmt where all files in the working directory are formatted regardless of if they are staged or committed to git. This is an undesirable behaviour for pre-commit as files should be passed to hooks by pre-commit rather than treating all files regardless.

In particular this causes an issue when the `PRE_COMMIT_HOME` environment variable is set to a path within the git repo (as per the [gitlab CI example](https://pre-commit.com/#gitlab-ci-example)) as the hook tries to lint files within .cache directories.

The current behaviour can be maintained if required by configuring the hook to run on all files in the working directory, but this is not the default behaviour of pre-commit and is not recommended - eg:
```yaml
    hooks:
    - id: conftest-fmt
      args:
        - '.' # Format all files
```

The conftest-validate hook has a similar issue and is also fixed by this PR.